### PR TITLE
Fix Vercel routing so frontend is accessible

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,9 +3,24 @@
     {
       "src": "api/index.py",
       "use": "@vercel/python"
+    },
+    {
+      "src": "index.html",
+      "use": "@vercel/static"
     }
   ],
   "routes": [
+    {
+      "src": "/",
+      "dest": "api/index.py"
+    },
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/ui",
+      "dest": "/index.html"
+    },
     {
       "src": "/(.*)",
       "dest": "api/index.py"


### PR DESCRIPTION
## Summary
- add a static Vercel build for `index.html`
- preserve API root behavior by explicitly routing `/` to `api/index.py`
- add `handle: filesystem` so static assets are served when present
- add `/ui` route as a friendly alias to `/index.html`
- keep API fallback route `/(.*) -> api/index.py` for all non-static paths

## Problem
`vercel.json` had a global catch-all to `api/index.py`, which made frontend files like `/index.html` unreachable in production.

## Validation
- confirmed repo contains frontend entry page at `index.html`
- validated updated `vercel.json` structure locally
- note: full `vercel build` validation depends on local project settings
