### PR TITLE
Add machine-readable scoring to eval scenarios

### DIFF
--- a/agent-sandbox/scenarios/scenarios.json
+++ b/agent-sandbox/scenarios/scenarios.json
@@ -11,7 +11,22 @@
       "expected_tools": ["lookup_member", "get_accumulator"],
       "expected_behavior": "Agent should look up the member, then retrieve their accumulator to show deductible used vs remaining.",
       "success_criteria": "Agent provides specific dollar amounts for deductible used, remaining, and total limit.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["deductible", "$", "remaining"],
+        "must_not_contain": ["I don't have access", "unable to find"],
+        "required_tool_calls": ["lookup_member", "get_accumulator"],
+        "tool_call_order": "lookup_member before get_accumulator"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-002",
@@ -22,7 +37,22 @@
       "expected_tools": ["lookup_member", "search_claims", "get_claim_detail", "check_benefits"],
       "expected_behavior": "Agent should identify the member, find the MRI claim, check the denial reason, and explain what went wrong (likely no prior auth).",
       "success_criteria": "Agent explains the specific denial reason, references the prior auth requirement, and offers to help with an appeal.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["denied", "prior auth", "appeal"],
+        "must_not_contain": ["I'm not sure why", "no claims found", "unable to determine"],
+        "required_tool_calls": ["lookup_member", "search_claims", "get_claim_detail"],
+        "tool_call_order": "lookup_member first, then search_claims, then get_claim_detail"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-003",
@@ -33,7 +63,22 @@
       "expected_tools": ["search_providers"],
       "expected_behavior": "Agent searches providers filtered by specialty=Cardiology, network_status=In-Network, accepting_new_patients=true, city=Chicago.",
       "success_criteria": "Agent returns provider names, addresses, and ratings. Mentions if referral is needed (HMO plans).",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["cardiologist", "in-network", "accepting new patients"],
+        "must_not_contain": ["no providers found", "I can't search"],
+        "required_tool_calls": ["search_providers"],
+        "tool_call_order": ""
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-004",
@@ -44,7 +89,22 @@
       "expected_tools": ["lookup_member", "get_member_coverage", "get_plan_formulary"],
       "expected_behavior": "Agent looks up the member, gets their plan, checks the formulary for Ozempic. Should flag that it's a specialty tier drug with prior auth required and step therapy (metformin first).",
       "success_criteria": "Agent states the tier, copay amount, prior auth requirement, and step therapy requirement. Explains what step therapy means.",
-      "agent_role": "Pharmacy Support"
+      "agent_role": "Pharmacy Support",
+      "expected_facts": {
+        "must_contain": ["tier", "copay", "prior auth", "step therapy"],
+        "must_not_contain": ["not covered", "I don't have formulary information"],
+        "required_tool_calls": ["lookup_member", "get_plan_formulary"],
+        "tool_call_order": "lookup_member before get_plan_formulary"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-005",
@@ -55,7 +115,22 @@
       "expected_tools": ["lookup_member", "get_authorization", "search_knowledge_base", "initiate_appeal"],
       "expected_behavior": "Agent finds the member, locates the denied auth, explains the appeal process from the knowledge base, and offers to initiate the appeal.",
       "success_criteria": "Agent explains the appeal timeline (30 days internal), required documents, and either initiates the appeal or explains next steps clearly.",
-      "agent_role": "Appeals Specialist"
+      "agent_role": "Appeals Specialist",
+      "expected_facts": {
+        "must_contain": ["30 days", "appeal", "documentation", "denied"],
+        "must_not_contain": ["I can't file an appeal", "no authorization found", "you'll need to call another department"],
+        "required_tool_calls": ["lookup_member", "get_authorization", "search_knowledge_base"],
+        "tool_call_order": "lookup_member first, get_authorization before search_knowledge_base"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-006",
@@ -66,7 +141,22 @@
       "expected_tools": ["lookup_member", "check_eligibility", "get_member_coverage"],
       "expected_behavior": "Agent verifies the member's eligibility for the specific date. Should also check if the surgery needs prior auth.",
       "success_criteria": "Agent confirms eligibility status and proactively mentions auth requirements for surgery.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["eligible", "March 15", "prior auth"],
+        "must_not_contain": ["I cannot verify", "no eligibility records"],
+        "required_tool_calls": ["lookup_member", "check_eligibility"],
+        "tool_call_order": "lookup_member before check_eligibility"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-007",
@@ -77,7 +167,22 @@
       "expected_tools": ["search_knowledge_base", "lookup_member", "check_benefits"],
       "expected_behavior": "Agent explains copay vs coinsurance clearly, then looks up the member's specific plan to tell them what applies for office visits.",
       "success_criteria": "Clear explanation of both terms with specific dollar amounts from the member's plan.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["copay", "coinsurance", "$", "fixed amount", "percentage"],
+        "must_not_contain": ["I'm not sure of the difference", "you should check your plan documents"],
+        "required_tool_calls": ["search_knowledge_base", "lookup_member", "check_benefits"],
+        "tool_call_order": ""
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-008",
@@ -88,7 +193,22 @@
       "expected_tools": ["lookup_member", "get_interaction_history", "search_claims", "get_accumulator"],
       "expected_behavior": "Agent retrieves full member context: demographics, recent interactions, claims history, and accumulator status.",
       "success_criteria": "Agent provides a comprehensive briefing with recent call notes, open cases, and relevant claim details.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["call", "claim", "billing", "history"],
+        "must_not_contain": ["no interaction history", "member not found"],
+        "required_tool_calls": ["lookup_member", "get_interaction_history", "search_claims"],
+        "tool_call_order": "lookup_member first"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-009",
@@ -99,7 +219,22 @@
       "expected_tools": ["lookup_member", "search_knowledge_base", "check_benefits"],
       "expected_behavior": "Agent should explain the prudent layperson standard — ER is covered at in-network rates regardless of network. Reference the No Surprises Act.",
       "success_criteria": "Agent reassures member about in-network rates for ER, explains the copay, and mentions the No Surprises Act protections.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["in-network rates", "No Surprises Act", "emergency", "copay"],
+        "must_not_contain": ["out-of-network rates apply", "you will be responsible for the full amount", "not covered"],
+        "required_tool_calls": ["lookup_member", "search_knowledge_base"],
+        "tool_call_order": "lookup_member before search_knowledge_base"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-010",
@@ -110,7 +245,22 @@
       "expected_tools": ["lookup_member", "search_claims", "get_claim_detail", "search_knowledge_base"],
       "expected_behavior": "Agent identifies this is an HMO plan requiring referrals for specialists. The denial was for missing referral.",
       "success_criteria": "Agent explains the HMO referral requirement, advises getting a referral from PCP, and explains how to resubmit or get retroactive referral.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["HMO", "referral", "PCP", "denied"],
+        "must_not_contain": ["PPO", "no referral needed", "I'm not sure why it was denied"],
+        "required_tool_calls": ["lookup_member", "search_claims", "get_claim_detail"],
+        "tool_call_order": "lookup_member first, search_claims before get_claim_detail"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-011",
@@ -121,7 +271,22 @@
       "expected_tools": ["lookup_member", "search_knowledge_base"],
       "expected_behavior": "Agent explains qualifying life event rules — 30 days to add newborn, coverage retroactive to birth date.",
       "success_criteria": "Agent states the 30-day window, explains retroactive coverage, and describes what documents are needed.",
-      "agent_role": "Enrollment Specialist"
+      "agent_role": "Enrollment Specialist",
+      "expected_facts": {
+        "must_contain": ["30 days", "qualifying life event", "retroactive", "birth certificate"],
+        "must_not_contain": ["open enrollment", "you'll have to wait", "not eligible"],
+        "required_tool_calls": ["lookup_member", "search_knowledge_base"],
+        "tool_call_order": ""
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-012",
@@ -132,7 +297,22 @@
       "expected_tools": ["lookup_member", "search_claims", "get_claim_detail", "search_knowledge_base", "submit_authorization_request", "initiate_appeal", "create_case_note"],
       "expected_behavior": "Agent handles multiple issues: (1) explains the MRI denial, (2) submits retroactive auth request, (3) initiates appeal on the denied claim, (4) checks auth requirements for the upcoming surgery, (5) creates a case note documenting everything.",
       "success_criteria": "Agent addresses all three issues (past denial, current auth, future surgery) and creates appropriate documentation.",
-      "agent_role": "Senior Agent"
+      "agent_role": "Senior Agent",
+      "expected_facts": {
+        "must_contain": ["denied", "prior auth", "appeal", "authorization request", "case note", "knee replacement"],
+        "must_not_contain": ["I can only help with one issue", "you'll need to call back", "nothing I can do"],
+        "required_tool_calls": ["lookup_member", "search_claims", "submit_authorization_request", "initiate_appeal", "create_case_note"],
+        "tool_call_order": "lookup_member first, search_claims before initiate_appeal, create_case_note last"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-013",
@@ -143,7 +323,22 @@
       "expected_tools": ["lookup_member", "get_member_coverage", "search_knowledge_base"],
       "expected_behavior": "Agent explains COBRA continuation rights — 18 months, full premium + 2% admin fee, same benefits.",
       "success_criteria": "Agent explains COBRA timeline, cost implications, and enrollment deadline (60 days).",
-      "agent_role": "Enrollment Specialist"
+      "agent_role": "Enrollment Specialist",
+      "expected_facts": {
+        "must_contain": ["COBRA", "18 months", "60 days", "premium"],
+        "must_not_contain": ["you'll lose coverage immediately", "no options available", "I'm not familiar with COBRA"],
+        "required_tool_calls": ["lookup_member", "search_knowledge_base"],
+        "tool_call_order": "lookup_member before search_knowledge_base"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-014",
@@ -154,7 +349,22 @@
       "expected_tools": ["lookup_member", "check_benefits", "search_claims"],
       "expected_behavior": "Agent checks the PT benefit limit (30 visits/year), then counts PT claims this year to calculate remaining.",
       "success_criteria": "Agent provides specific number of visits used and remaining, and mentions auth requirement if limit is approaching.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["physical therapy", "visits", "remaining", "per year"],
+        "must_not_contain": ["unlimited visits", "I can't determine your visit count"],
+        "required_tool_calls": ["lookup_member", "check_benefits", "search_claims"],
+        "tool_call_order": "lookup_member first, check_benefits before search_claims"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-015",
@@ -165,7 +375,22 @@
       "expected_tools": ["lookup_member", "search_pharmacy_claims", "search_knowledge_base"],
       "expected_behavior": "Agent looks up current Rx costs, then explains the mail order benefit (90-day supply for 2x copay).",
       "success_criteria": "Agent calculates specific savings comparing 3 monthly fills vs 1 mail order fill.",
-      "agent_role": "Pharmacy Support"
+      "agent_role": "Pharmacy Support",
+      "expected_facts": {
+        "must_contain": ["mail order", "90-day", "savings", "$"],
+        "must_not_contain": ["mail order is not available", "no pharmacy claims found"],
+        "required_tool_calls": ["lookup_member", "search_pharmacy_claims"],
+        "tool_call_order": "lookup_member before search_pharmacy_claims"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-016",
@@ -176,7 +401,22 @@
       "expected_tools": ["search_knowledge_base"],
       "expected_behavior": "Agent explains COB rules — birthday rule for dependents, primary/secondary payer determination.",
       "success_criteria": "Agent clearly explains the birthday rule and primary vs secondary insurance concepts.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["birthday rule", "primary", "secondary", "coordination of benefits"],
+        "must_not_contain": ["I'm not sure which plan pays first", "you'll need to contact your spouse's insurer"],
+        "required_tool_calls": ["search_knowledge_base"],
+        "tool_call_order": ""
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-017",
@@ -187,7 +427,22 @@
       "expected_tools": ["lookup_member", "generate_document"],
       "expected_behavior": "Agent verifies the member and generates a new ID card.",
       "success_criteria": "Agent confirms member identity and generates the ID card document.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["ID card", "generated", "member"],
+        "must_not_contain": ["I can't generate documents", "you'll need to request one by mail"],
+        "required_tool_calls": ["lookup_member", "generate_document"],
+        "tool_call_order": "lookup_member before generate_document"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-018",
@@ -198,7 +453,22 @@
       "expected_tools": ["lookup_member", "search_claims", "search_knowledge_base"],
       "expected_behavior": "Agent explains the difference between billed, allowed, plan paid, and member responsibility. Explains that the member is NOT responsible for the difference between billed and allowed for in-network providers.",
       "success_criteria": "Clear explanation of EOB line items and reassurance about the billed vs allowed gap.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["billed amount", "allowed amount", "member responsibility", "in-network"],
+        "must_not_contain": ["you owe the full $3,500", "you are being overcharged", "I can't explain EOBs"],
+        "required_tool_calls": ["lookup_member", "search_claims"],
+        "tool_call_order": "lookup_member first"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-019",
@@ -209,7 +479,22 @@
       "expected_tools": ["lookup_member", "check_benefits", "search_knowledge_base"],
       "expected_behavior": "Agent confirms telehealth is covered and provides the copay amount from the member's plan.",
       "success_criteria": "Agent confirms telehealth coverage, states the copay, and explains it's the same as in-person equivalent.",
-      "agent_role": "Member Services"
+      "agent_role": "Member Services",
+      "expected_facts": {
+        "must_contain": ["telehealth", "covered", "copay", "$"],
+        "must_not_contain": ["telehealth is not covered", "virtual visits are not available"],
+        "required_tool_calls": ["lookup_member", "check_benefits"],
+        "tool_call_order": "lookup_member before check_benefits"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     },
     {
       "id": "EVAL-020",
@@ -220,7 +505,22 @@
       "expected_tools": ["lookup_member", "get_interaction_history", "search_claims", "search_knowledge_base", "create_case_note"],
       "expected_behavior": "Agent should de-escalate, review the interaction history to understand the issue, address the underlying claim problem, explain the grievance process, and document the complaint.",
       "success_criteria": "Agent acknowledges frustration, reviews past interactions, addresses the claim issue, explains grievance filing, and creates documentation.",
-      "agent_role": "Supervisor"
+      "agent_role": "Supervisor",
+      "expected_facts": {
+        "must_contain": ["apologize", "grievance", "case note", "denied claim", "interaction history"],
+        "must_not_contain": ["there's nothing I can do", "you'll need to call back again", "I don't see any previous calls"],
+        "required_tool_calls": ["lookup_member", "get_interaction_history", "search_claims", "create_case_note"],
+        "tool_call_order": "lookup_member first, get_interaction_history before search_claims, create_case_note last"
+      },
+      "scoring": {
+        "weights": {
+          "correct_tools_called": 30,
+          "correct_tool_order": 20,
+          "facts_present": 30,
+          "no_forbidden_phrases": 20
+        },
+        "pass_threshold": 70
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `expected_facts` and `scoring` fields to all 20 eval scenarios in `scenarios.json`
- `must_contain`: 2-6 specific terms per scenario (e.g., "No Surprises Act", "HMO", "$", "30 days")
- `must_not_contain`: failure phrases and wrong answers to flag
- `required_tool_calls` and `tool_call_order` for tool verification
- Weighted scoring: tools called (30%), tool order (20%), facts present (30%), no forbidden phrases (20%)
- 70% pass threshold across all scenarios
- No existing fields changed — fully backwards compatible

## Test plan
- [x] JSON valid — `json.load()` succeeds
- [x] All 20 scenarios have both new fields
- [x] Existing eval runner still passes 20/20
- [x] Spot-checked EVAL-001, 009, 010, 012 for specificity

🤖 Generated with [Claude Code](https://claude.com/claude-code)